### PR TITLE
Added failover for loading config + do not auto write config.

### DIFF
--- a/plugins/coresense_4/plugin.py
+++ b/plugins/coresense_4/plugin.py
@@ -99,50 +99,43 @@ class DeviceHandler(object):
         self.serial.write(bytes(buffer))
         return self.read_response()
 
+
+default_config_table = {
+    'MetMAC': {'sensor_id': 0x00, 'function_call': 'sensor_read', 'interval': 25},
+    'TMP112': {'sensor_id': 0x01, 'function_call': 'sensor_read', 'interval': 25},
+    'HTU21D': {'sensor_id': 0x02, 'function_call': 'sensor_read', 'interval': 25},
+    'HIH4030': {'sensor_id': 0x03, 'function_call': 'sensor_read', 'interval': 25},
+    'BMP180': {'sensor_id': 0x04, 'function_call': 'sensor_read', 'interval': 25},
+    'PR103J2': {'sensor_id': 0x05, 'function_call': 'sensor_read', 'interval': 25},
+    'TSL250RDMS': {'sensor_id': 0x06, 'function_call': 'sensor_read', 'interval': 25},
+    'MMA8452Q': {'sensor_id': 0x07, 'function_call': 'sensor_read', 'interval': 25},
+    'SPV1840LR5H-B': {'sensor_id': 0x08, 'function_call': 'sensor_read', 'interval': 25},
+    'TSYS01': {'sensor_id': 0x09, 'function_call': 'sensor_read', 'interval': 25},
+    'HMC5883L': {'sensor_id': 0x0A, 'function_call': 'sensor_read', 'interval': 25},
+    'HIH6130': {'sensor_id': 0x0B, 'function_call': 'sensor_read', 'interval': 25},
+    'APDS_9006_020': {'sensor_id': 0x0C, 'function_call': 'sensor_read', 'interval': 25},
+    'TSL260': {'sensor_id': 0x0D, 'function_call': 'sensor_read', 'interval': 25},
+    'TSL250RDLS': {'sensor_id': 0x0E, 'function_call': 'sensor_read', 'interval': 25},
+    'MLX75305': {'sensor_id': 0x0F, 'function_call': 'sensor_read', 'interval': 25},
+    'ML8511': {'sensor_id': 0x10, 'function_call': 'sensor_read', 'interval': 25},
+    'TMP421': {'sensor_id': 0x13, 'function_call': 'sensor_read', 'interval': 25},
+    'Chemsense': {'sensor_id': 0x2A, 'function_call': 'sensor_read', 'interval': 25},
+    'AlphaFirmware': {'sensor_id': 0x30, 'function_call': 'sensor_read', 'interval': 25},
+    'AlphaSerial': {'sensor_id': 0x29, 'function_call': 'sensor_read', 'interval': 25},
+    'AlphaHisto': {'sensor_id': 0x28, 'function_call': 'sensor_read', 'interval': 25},
+}
+
+
 def get_config_table():
     sensor_config_file = '/wagglerw/waggle/sensor_table.conf'
-    sensor_table = None
-    if os.path.isfile(sensor_config_file):
+
+    try:
         with open(sensor_config_file) as config:
-            sensor_table = json.loads(config.read())
-    else:
-        sensor_table = {
-            'MetMAC': { 'sensor_id': 0x00, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'TMP112': { 'sensor_id': 0x01, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'HTU21D': { 'sensor_id': 0x02, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'HIH4030': { 'sensor_id': 0x03, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'BMP180': { 'sensor_id': 0x04, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'PR103J2': { 'sensor_id': 0x05, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'TSL250RDMS': { 'sensor_id': 0x06, 'function_call': 'sensor_read', 'interval': 25 },  #o, light, return raw
-            'MMA8452Q': { 'sensor_id': 0x07, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'SPV1840LR5H-B': { 'sensor_id': 0x08, 'function_call': 'sensor_read', 'interval': 25 },  #o 63 readings
-            'TSYS01': { 'sensor_id': 0x09, 'function_call': 'sensor_read', 'interval': 25 },  #o
+            return json.loads(config.read())
+    except Exception as exc:
+        print('Error loading sensor_table.conf! Reverting to default.')
 
-            'HMC5883L': { 'sensor_id': 0x0A, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'HIH6130': { 'sensor_id': 0x0B, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'APDS_9006_020': { 'sensor_id':0x0C, 'function_call': 'sensor_read', 'interval': 25 },  #o, light, return raw
-            'TSL260': { 'sensor_id': 0x0D, 'function_call': 'sensor_read', 'interval': 25 },  #o, light, return raw
-            'TSL250RDLS': { 'sensor_id': 0x0E, 'function_call': 'sensor_read', 'interval': 25 },  #o, light, return raw
-            'MLX75305': { 'sensor_id': 0x0F, 'function_call': 'sensor_read', 'interval': 25 },  #o, light, return raw
-            'ML8511': { 'sensor_id': 0x10, 'function_call': 'sensor_read', 'interval': 25 },  #o, light, return raw
-            'TMP421': { 'sensor_id': 0x13, 'function_call': 'sensor_read', 'interval': 25 },  #o
-
-            # 'BusTMP112': { 'function_call': 'bus_read', 'bus_type': 0x00, 'bus_address': 0x48, 'params': [0x00], 'interval': 1 },
-            # 'BusHTU21D': { 'function_call': 'bus_read', 'bus_type': 0x00, 'bus_address': 0x40, 'params': [0xF3, 0xF5], 'interval': 1 },
-            # 'BusChemsense': { 'function_call': 'bus_read', 'bus_type': 0x02, 'bus_address': 0x03, 'params': [], 'interval': 1 },
-
-            # 'ChemConfig': { 'sensor_id': 0x16, 'function_call': 'sensor_read', 'interval': 1 },  #o
-            'Chemsense': { 'sensor_id': 0x2A, 'function_call': 'sensor_read', 'interval': 25 },  #o
-
-            # 'AlphaON': { 'sensor_id': 0x2B, 'function_call': 'sensor_read', 'interval': 1 },  #o
-            'AlphaFirmware': { 'sensor_id': 0x30, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'AlphaSerial': { 'sensor_id': 0x29, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            'AlphaHisto': { 'sensor_id': 0x28, 'function_call': 'sensor_read', 'interval': 25 },  #o
-            # 'AlphaConfig': { 'sensor_id': 0x31, 'function_call': 'sensor_read', 'interval': 1 },
-        }
-        with open(sensor_config_file, 'w') as config:
-            config.write(json.dumps(sensor_table))
-    return sensor_table
+    return default_config_table
 
 
 class CoresensePlugin4(Plugin):


### PR DESCRIPTION
I think it makes sense to provide failure behavior to the coresense 4 plugin when attempting to load it's config. Among other things, user typos, file corruption, etc can prevent the plugin from running. The proposed logic attempts to load the file, but if it fails in any way, the plugin uses the built-in default table.

I also dropped rewriting the config file each time the plugin attempts to get its config.